### PR TITLE
removing svn legacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 
 build
+depcache

--- a/start.sh
+++ b/start.sh
@@ -39,7 +39,7 @@ if [ -f ~/.jlatexeditor/settings.conf ]; then
   source ~/.jlatexeditor/settings.conf
 fi
 
-svn up
+git pull origin master
 ant clearDependentClasses
 ant compile
 

--- a/startDebug.sh
+++ b/startDebug.sh
@@ -18,7 +18,7 @@ fi
 
 cd `dirname $0`
 
-svn up
+git pull origin master
 ant clearDependentClasses
 ant compile
 


### PR DESCRIPTION
- Replacing the svn commands with git in the start scripts.
- update gitignore to exclude depcache folder

Closing #2 